### PR TITLE
imports to dynamically load all modules from the functions directory

### DIFF
--- a/Company_Name/main.ps1
+++ b/Company_Name/main.ps1
@@ -2,10 +2,11 @@ param (
     [string]$Action
 )
 
-# Import your custom module
-Import-Module .\functions\GetInstalledApps.psm1 -Force
-Import-Module .\functions\Generate-List.psm1 -Force
-Import-Module .\functions\Install-Apps.psm1 -Force
+# Loops the .\functions directory and imports all modules found there.
+$imports = (Get-ChildItem -Path .\functions).Name
+foreach ($module in $imports) {
+    import-module .\functions\$module -Force
+}
 
 switch ($Action) {
     "Extract" {


### PR DESCRIPTION
Change to main.ps1 to loop through the .\functons folder. so that any .psm1s get imported there instead of statically adding imports to the main.ps1